### PR TITLE
Arreglo de despliegue: copia de public en dockerfile y actualización de README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.gitignore
+README.md
+.env*.local
+.next
+.vercel
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /app
 # Copy the built application from the builder stage
 COPY --from=builder /app/.next ./.next
 
+# Copy the public folder for static assets
+COPY --from=builder /app/public ./public
+
 # Copy package.json for production dependencies
 COPY ./app/package*.json ./
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,61 @@
-MIPS Visual Simulator Pipeline
+# MIPS Visual Simulator Pipeline
 
+A JavaScript-based MIPS simulator that can simulate the MIPS assembly code with visual pipeline representation.
 
-A javascript based MIPS simulator that can simulate the MIPS assembly code. 
+### Prerequisites
+- Docker and Docker Compose installed
+- Node.js (for development mode)
 
-To run on dev mode, run the following command
+### Running with Docker (Recommended)
+
+1. **Clone the repository:**
+   ```bash
+   git clone <repository-url>
+   cd mips_pipeline_viewer
+   ```
+
+2. **Run with Docker Compose (simplest method):**
+   ```bash
+   docker-compose up -d
+   ```
+   
+   Your application will be available at: http://localhost:3000
+
+3. **Useful Docker Compose commands:**
+   ```bash
+   # Stop the application
+   docker-compose stop
+   
+   # Stop and remove containers
+   docker-compose down
+   
+   # View logs
+   docker-compose logs
+   
+   # Rebuild and run (after code changes)
+   docker-compose up --build -d
+   ```
+
+### Development Mode
+
+To run in development mode with hot reload:
+
 ```bash
- cd app
- nmp install
- npm run dev 
+cd app
+npm install
+npm run dev
 ```
 
-To deply the app, run the following command
+The development server will start at: http://localhost:3000
+
+### Manual Docker Build (Alternative)
+
+If you prefer manual Docker commands:
+
 ```bash
- docker build -t mipspipelinei .
- docker run -d -it -p 5031:3000 --restart unless-stopped --name mipspipeline mipspipelinei
+# Build the image
+docker build -t mips-pipeline-viewer .
+
+# Run the container
+docker run -p 3000:3000 -d --name mips-pipeline mips-pipeline-viewer
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  mips-pipeline:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    container_name: mips-pipeline-viewer


### PR DESCRIPTION
La imagen `datapath.jpg` no se mostraba en la opción **Graphics Datapath Overlay** porque en la construcción del `Dockerfile` no se realizaba la copia de la carpeta `public`. 

Se actualizó el **README** con instrucciones más precisas sobre el proceso de deploy para el correcto desarrollo y despliegue de la aplicación.

**Antes:**
<img width="1898" height="1006" alt="image" src="https://github.com/user-attachments/assets/1b26b5da-37aa-4e15-8dd1-8bff8856071d" />

**Despues:**
<img width="1901" height="1030" alt="image" src="https://github.com/user-attachments/assets/5f3160f9-21ee-469c-ba76-649e7d042073" />

**Prueba local solo con docker-compose up**
<img width="1792" height="995" alt="image" src="https://github.com/user-attachments/assets/ac4cd299-1063-40b5-982d-7b2e59241141" />
